### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "mongoose": "^5.5.6",
     "mongoose-unique-validator": "^2.0.3",
     "node-sass": "^4.12.0",
-    "npm": "^6.9.0",
     "paypal-checkout": "^4.0.268",
     "react": "^16.8.6",
     "react-async-script-loader": "^0.3.0",


### PR DESCRIPTION

Hello leeofham!

It seems like you have npm as one of your (dev-) dependency in SEI-Project-3.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
